### PR TITLE
Patch docker-cli for WSL.

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -3,13 +3,16 @@ name: Build binaries and create a draft release
 on:
   push:
     tags: ['*']
+  workflow_dispatch:
+    inputs:
+      TAG:
+        description: Docker CLI tag to build
+        required: true
+        default: v20.10.17
 
 defaults:
   run:
     shell: bash
-
-env:
-  DOCKER_CLI_REF: v20.10.17
 
 jobs:
   build:
@@ -17,93 +20,151 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
 
-    steps:
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+    defaults:
+      run:
+        working-directory: cli
 
-    - uses: actions/checkout@v2
+    steps:
+    - name: Set Docker CLI tag from tag
+      if: startsWith(github.event.ref, 'refs/tags/')
+      run: |
+        DOCKER_CLI_REF="${{ github.event.ref }}"
+        echo "DOCKER_CLI_REF=${DOCKER_CLI_REF#refs/tags/}" >> "${GITHUB_ENV}"
+      working-directory: .
+
+    - name: Set Docker CLI tag from inputs
+      if: inputs.TAG
+      run: echo "DOCKER_CLI_REF=${{ inputs.TAG }}" >> "${GITHUB_ENV}"
+      working-directory: .
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Check out build scripts
+      uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+        path: rancher-desktop-docker-cli
+
+    - name: Check out docker/cli
+      uses: actions/checkout@v3
       with:
         repository: docker/cli
         ref: ${{ env.DOCKER_CLI_REF }}
         persist-credentials: false
+        path: cli
 
-    # Workaround the "dirty version bug" in https://github.com/docker/cli/pull/3349
-    # The assignment is from https://github.com/docker/cli/blob/e57b5f78de635e6e2b688686d10b830c4747c4dc/scripts/build/.variables#L7
+    # Override the build version (ignoring commits from our patches).
+    # The assignment is from https://github.com/docker/cli/blob/e57b5f78/scripts/build/.variables#L7
     - name: Override CLI Version
       run: |
-        VERSION=${VERSION:-$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags | sed 's/^v//' 2>/dev/null)}
+        VERSION=${VERSION:-$(git describe --match 'v[0-9]*' --dirty='.m' --always --tags 2>/dev/null)}
         if [ -n "$VERSION" ] ; then
-          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION#v}-rd" >> $GITHUB_ENV
         fi
 
+    - name: Apply patches
+      run: |
+        set -o errexit
+        for patch in $(ls -1 ${GITHUB_WORKSPACE}/rancher-desktop-docker-cli/patches/*) ; do
+          git am "${patch}"
+        done
+      env:
+        GIT_AUTHOR_NAME: Rancher Desktop CI Automation
+        GIT_AUTHOR_EMAIL: nobody@rancherdesktop.io
+        GIT_COMMITTER_NAME: Rancher Desktop CI Automation
+        GIT_COMMITTER_EMAIL: nobody@rancherdesktop.io
+
     - name: Build darwin amd64
-      uses: docker/bake-action@v1
+      uses: docker/bake-action@v2.2.0
       with:
-        set: "binary.platform=darwin/amd64"
+        set: binary.platform=darwin/amd64
+        workdir: cli
 
     - name: Build darwin arm64
-      uses: docker/bake-action@v1
+      uses: docker/bake-action@v2.2.0
       with:
-        set: "binary.platform=darwin/arm64"
+        set: binary.platform=darwin/arm64
+        workdir: cli
 
-    - name: Build linux
-      uses: docker/bake-action@v1
+    - name: Build WSL amd64
+      uses: docker/bake-action@v2.2.0
       with:
-       set: "binary.platform=linux/amd64"
+        set: |
+          binary.platform=linux/amd64
+          binary.args.GO_LDFLAGS=-X github.com/docker/cli/cli/config/credentials.LinuxCredentialsStoreDefaultOverride=wincred.exe
+        workdir: cli
 
-    - name: Build on Windows
-      uses: docker/bake-action@v1
+    - run: mv ./build/docker-linux-amd64 ./build/docker-wsl-amd64
+
+    - name: Build linux amd64
+      uses: docker/bake-action@v2.2.0
       with:
-        set: "binary.platform=windows/amd64"
+        set: binary.platform=linux/amd64
+        workdir: cli
+
+    - name: Build windows amd64
+      uses: docker/bake-action@v2.2.0
+      with:
+        set: binary.platform=windows/amd64
+        workdir: cli
 
     - name:  Calculate Checksums
-      working-directory: "./build"
+      working-directory: cli/build
       run: sha256sum docker-* > sha256sum.txt
 
     - uses: actions/upload-artifact@v2
       name: Upload Darwin amd64 artifact
       with:
         name: docker-darwin-amd64
-        path: ./build/docker-darwin-amd64
+        path: cli/build/docker-darwin-amd64
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v2
       name: Upload Darwin arm64 artifact
       with:
         name: docker-darwin-arm64
-        path: ./build/docker-darwin-arm64
+        path: cli/build/docker-darwin-arm64
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v2
       name: Upload Linux artifact
       with:
         name: docker-linux-amd64
-        path: ./build/docker-linux-amd64
+        path: cli/build/docker-linux-amd64
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v2
       name: Upload Windows artifact
       with:
         name: docker-windows-amd64
-        path: ./build/docker-windows-amd64.exe
+        path: cli/build/docker-windows-amd64.exe
+        if-no-files-found: error
+
+    - uses: actions/upload-artifact@v2
+      name: Upload WSL artifact
+      with:
+        name: docker-wsl-amd64
+        path: cli/build/docker-wsl-amd64
         if-no-files-found: error
 
     - uses: actions/upload-artifact@v2
       name: Upload checksums
       with:
         name: sha256sum.txt
-        path: ./build/sha256sum.txt
+        path: cli/build/sha256sum.txt
         if-no-files-found: error
 
     - name: Create draft release
+      if: startsWith(github.event.ref, 'refs/tags/')
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ref: ${{ env.DOCKER_CLI_REF }}
       run: >-
         gh release create
-        "${ref}"
+        "${DOCKER_CLI_REF}"
         ./build/docker-*
         ./build/sha256sum.txt
         --draft
-        --title "${tag}"
-        --repo ${{ github.repository }}
+        --title "Docker CLI builds for docker ${{ github.ref_name }}"
+        --notes "Docker CLI builds for docker ${{ github.ref_name }}"
+        --repo "${{ github.repository }}"

--- a/README.md
+++ b/README.md
@@ -1,28 +1,23 @@
 # docker-cli-release
 Repo for building and releasing the Docker CLI for different platforms.
 
-To create a populated release:
+## Creating a populated release:
 
 1. Get the tag of the docker CLI release you want to build, e.g. "v20.10.10" (called `TAG`)
 
-1. Set the value of `DOCKER_CLI_REF` to the new tag in `.github/workflows/package.yaml`
+1. `git tag TAG` (from whatever `main` is).
 
-1. `git add` and `git commit` the change with description
-`Bump to use Docker CLI [TAG]`
+1. `git push origin refs/tags/${TAG}`.
 
-1. `git tag TAG`
-
-1. `git push origin main --tags`
-
-1. Let the github packager do its thing
+1. Let GitHub CI do its thing.  This will generate a draft release.
 
 1. Then go build a release:
 
 Go to https://github.com/rancher-sandbox/rancher-desktop-docker-cli/releases
-and create a new release, and tell it to create the tag `TAG`.
+and edit the draft release.
 
-Set the title and description to `Docker CLI builds for docker TAG`
+## Manually triggering builds
 
-Publish the release. This has to be a final release, not a draft release,
-so for a while it will be visible without the associated binaries
-until the github actions build, upload, and attach them.
+It's possible to manually trigger a build (via GitHub Actions, manually use the
+_Run workflow_ button); builds triggered this way will not create a draft
+release.

--- a/patches/0001-Credentials-Linux-Allow-overriding-default-credentia.patch
+++ b/patches/0001-Credentials-Linux-Allow-overriding-default-credentia.patch
@@ -1,0 +1,52 @@
+From 1813c0d1ce5026d14a03a4f4c8a67f388e864940 Mon Sep 17 00:00:00 2001
+From: Mark Yen <mark.yen@suse.com>
+Date: Thu, 21 Jul 2022 11:07:40 -0700
+Subject: [PATCH] Credentials: Linux: Allow overriding default credential
+ store.
+
+This adds a compile-time option to override the default credential store,
+so that we can provide a different default for WSL installs of Rancher
+Desktop.
+
+Signed-off-by: Mark Yen <mark.yen@suse.com>
+---
+ Dockerfile                                    | 2 ++
+ cli/config/credentials/default_store_linux.go | 8 ++++++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/Dockerfile b/Dockerfile
+index 4c2b4cd6d8..6ea5fb2bf1 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -26,6 +26,8 @@ ARG TARGETPLATFORM
+ RUN xx-apt install --no-install-recommends -y libc6-dev libgcc-8-dev
+ 
+ FROM build-${BASE_VARIANT} AS build
++# GO_LDFLAGS defines additional linker arguments
++ARG GO_LDFLAGS
+ # GO_LINKMODE defines if static or dynamic binary should be produced
+ ARG GO_LINKMODE=static
+ # GO_BUILDTAGS defines additional build tags
+diff --git a/cli/config/credentials/default_store_linux.go b/cli/config/credentials/default_store_linux.go
+index a9012c6d4a..1288694474 100644
+--- a/cli/config/credentials/default_store_linux.go
++++ b/cli/config/credentials/default_store_linux.go
+@@ -4,7 +4,15 @@ import (
+ 	"os/exec"
+ )
+ 
++// LinuxCredentialsStoreDefaultOverride is a link-time override for the default
++// credentials store to use on Linux; this is set in the build scripts for
++// rancher-desktop-docker-cli for use in WSL.
++var LinuxCredentialsStoreDefaultOverride string
++
+ func defaultCredentialsStore() string {
++	if LinuxCredentialsStoreDefaultOverride != "" {
++		return LinuxCredentialsStoreDefaultOverride
++	}
+ 	if _, err := exec.LookPath("pass"); err == nil {
+ 		return "pass"
+ 	}
+-- 
+2.32.0
+


### PR DESCRIPTION
This is a partial fix for https://github.com/rancher-sandbox/rancher-desktop/issues/2567 — after this PR, we will still need to update RD to use the new WSL binary.

This commit does a few related things:
- Modify the GitHub workflow to allow patching the source code.
- Add a patch which allows us to override the Linux default credentials store via a build option.
- Modify the GitHub workflow to add a WSL build
  - In this WSL build, provide the build option to use `wincred.exe` for the default credentials store.
- Bump the various actions used.
- Simplify the happy-path build process to just require tagging.
- Specify that the docker CLI builds are from us (by appending to the version string).

Test builds:
- [manually triggered](https://github.com/mook-as/rancher-desktop-docker-cli/actions/runs/2715436022)
- [tag triggered](https://github.com/mook-as/rancher-desktop-docker-cli/actions/runs/2715433436)
